### PR TITLE
[v4.0.1] Use explicitly nullable types to support PHP 8.4.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v4.0.1
+
++ Use explicitly nullable types to support PHP 8.4.
+
 ## v4.0.0
 
 + AB#114583 Bump dependencies for Laravel 12 and phpunit 11.

--- a/src/SimfoniServiceProvider.php
+++ b/src/SimfoniServiceProvider.php
@@ -75,7 +75,7 @@ class SimfoniServiceProvider extends ServiceProvider
      * @param  callable|null  $function
      * @return JsonResponse|RedirectResponse
      */
-    public static function exceptionHandling($request, Exception $exception, callable $function = null)
+    public static function exceptionHandling($request, Exception $exception, ?callable $function = null)
     {
         if (route_contains('async') || route_contains('api')) {
             if ($exception instanceof ValidationException) {


### PR DESCRIPTION
## v4.0.1

+ Use explicitly nullable types to support PHP 8.4.